### PR TITLE
Just getting rid of some warnings with VS2022

### DIFF
--- a/coffi/coffi_directory.hpp
+++ b/coffi/coffi_directory.hpp
@@ -36,6 +36,15 @@ THE SOFTWARE.
 #include <coffi/coffi_headers.hpp>
 #include <coffi/coffi_section.hpp>
 
+#if defined(__has_include) && __has_include(<gsl/narrow>)
+#include <gsl/narrow>
+using gsl::narrow_cast;
+#else
+#ifndef narrow_cast
+#define narrow_cast static_cast
+#endif
+#endif
+
 namespace COFFI {
 
 //! Class for accessing an image data directory
@@ -219,7 +228,7 @@ class directories : public std::vector<directory*>
     uint32_t get_sizeof() const
     {
         if (size() > 0) {
-            return size() * (*begin())->get_sizeof();
+            return narrow_cast<uint32_t>(size() * (*begin())->get_sizeof());
         }
         return 0;
     }

--- a/coffi/coffi_headers.hpp
+++ b/coffi/coffi_headers.hpp
@@ -34,6 +34,15 @@ THE SOFTWARE.
 
 #include <coffi/coffi_utils.hpp>
 
+#if defined(__has_include) && __has_include(<gsl/narrow>)
+#include <gsl/narrow>
+using gsl::narrow_cast;
+#else
+#ifndef narrow_cast
+#define narrow_cast static_cast
+#endif
+#endif
+
 namespace COFFI {
 
 //------------------------------------------------------------------------------
@@ -179,7 +188,7 @@ class dos_header
     //------------------------------------------------------------------------------
     void set_stub(const std::string& data)
     {
-        set_stub(data.c_str(), data.size());
+        set_stub(data.c_str(), narrow_cast<uint32_t>(data.size()));
     }
 
     //------------------------------------------------------------------------------

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -35,6 +35,15 @@ THE SOFTWARE.
 #include <coffi/coffi_utils.hpp>
 #include <coffi/coffi_relocation.hpp>
 
+#if defined(__has_include) && __has_include(<gsl/narrow>)
+#include <gsl/narrow>
+using gsl::narrow_cast;
+#else
+#ifndef narrow_cast
+#define narrow_cast static_cast
+#endif
+#endif
+
 namespace COFFI {
 
 //------------------------------------------------------------------------------
@@ -218,7 +227,7 @@ template <class T> class section_impl_tmpl : public section
         r.set_virtual_address(entry->virtual_address);
         r.set_symbol(entry->symbol_table_index);
         relocations.push_back(r);
-        set_reloc_count(relocations.size());
+        set_reloc_count(narrow_cast<uint32_t>(relocations.size()));
     }
 
     //------------------------------------------------------------------------------
@@ -296,7 +305,7 @@ template <class T> class section_impl_tmpl : public section
     virtual uint32_t get_relocations_filesize()
     {
         relocation rel{stn_, sym_, arch_};
-        return rel.get_sizeof() * relocations.size();
+        return rel.get_sizeof() * narrow_cast<uint32_t>(relocations.size());
     }
 
     //------------------------------------------------------------------------------
@@ -310,7 +319,7 @@ template <class T> class section_impl_tmpl : public section
     //------------------------------------------------------------------------------
     virtual uint32_t get_line_numbers_filesize()
     {
-        return sizeof(line_number) * line_numbers.size();
+        return sizeof(line_number) * narrow_cast<uint32_t>(line_numbers.size());
     }
 
     //------------------------------------------------------------------------------

--- a/coffi/coffi_strings.hpp
+++ b/coffi/coffi_strings.hpp
@@ -200,8 +200,9 @@ class coffi_strings : public virtual string_to_name_provider
             size++;
             uint32_t offset = get_strings_size();
             if (get_strings_size() + size > strings_reserved_) {
-                uint32_t new_strings_reserved = 2 * (strings_reserved_ + size);
-                char*    new_strings          = new char[new_strings_reserved];
+                uint32_t new_strings_reserved =
+                    2 * (strings_reserved_ + narrow_cast<uint32_t>(size));
+                char* new_strings = new char[new_strings_reserved];
                 if (!new_strings) {
                     offset = 0;
                     size   = 0;
@@ -216,7 +217,7 @@ class coffi_strings : public virtual string_to_name_provider
             }
             std::copy(name.c_str(), name.c_str() + size,
                       strings_ + get_strings_size());
-            set_strings_size(get_strings_size() + size);
+            set_strings_size(get_strings_size() + narrow_cast<uint32_t>(size));
             if (is_section) {
                 str[0]        = '/';
                 std::string s = std::to_string(offset);

--- a/examples/COFFDump/COFFDump.vcxproj
+++ b/examples/COFFDump/COFFDump.vcxproj
@@ -27,26 +27,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -85,7 +85,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -99,7 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,7 +115,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -133,6 +133,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
- Adding `gsl::narrow_cast` in some places where the code does a narrowing cast. The newly introduced code checks if the respective header is available and otherwise uses static_cast in place of narrow_cast.
- Project fixed to reference the include directory from two levels up.
- Project (`.vcxproj`) updated to VS2022.
- Some spelling fixes.
- Changed files were reformatted with the existing clang-format rules.

-----

One remaining question would be if [`gsl::narrow` -- the checked version of `gsl::narrow_cast`](https://github.com/microsoft/GSL) -- should be used. Also there are a handful of narrowing casts which still cause warnings, behind macros.

Please note that if the library is built without the GSL headers or on a compiler that doesn't support `__has_include`, it will simply resort to `#define narrow_cast static_cast` to silence the warnings, but without the effect of documenting the intentional nature of the narrowing cast.

PS: canonical project files as saved by VS use CRLF line endings, this meant that the file changed as a whole, pretty much.