### PR TITLE
Fixing issues mentioned in #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 COFFI is a header-only C++ library intended for reading and generating files in the COFF binary format.
 It is used as a standalone library - it is not dependant on any other product or project.
-Adhering to ISO C++, it compiles on a wide variety of architectures and compilers.
+Adhering to ISO C++ (C++14 and newer), it compiles on a wide variety of architectures and compilers.
 
 As the COFF binary format standard is extended or violated in many implementations,
 this library only supports a very small subset of the COFF implementations:

--- a/coffi/coffi.hpp
+++ b/coffi/coffi.hpp
@@ -42,6 +42,7 @@ THE SOFTWARE.
 #include <sstream>
 #include <algorithm>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 #include <coffi/coffi_types.hpp>
@@ -646,24 +647,24 @@ class coffi : public coffi_strings,
     {
         std::streampos pos = stream.tellg();
         for (int i = 0; i < coff_header_->get_sections_count(); ++i) {
-            section* sec;
+            std::unique_ptr<section> sec;
             switch (architecture_) {
             case COFFI_ARCHITECTURE_PE:
             case COFFI_ARCHITECTURE_CEVA:
-                sec = new section_impl(this, this, this);
+                sec = std::make_unique<section_impl>(this, this, this);
                 break;
             case COFFI_ARCHITECTURE_TI:
-                sec = new section_impl_ti(this, this, this);
+                sec = std::make_unique<section_impl_ti>(this, this, this);
                 break;
             default:
-                sec = new section_impl(this, this, this);
+                sec = std::make_unique<section_impl>(this, this, this);
                 break;
             }
             if (!(sec->load(stream, i * sec->get_sizeof() + pos))) {
                 return false;
             }
             sec->set_index(i);
-            sections_.push_back(sec);
+            sections_.push_back(sec.release());
         }
 
         return true;

--- a/coffi/coffi_directory.hpp
+++ b/coffi/coffi_directory.hpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #define COFFI_DIRECTORY_HPP
 
 #include <iostream>
+#include <memory>
 #include <vector>
 
 #include <coffi/coffi_utils.hpp>
@@ -163,7 +164,7 @@ class directory
     }
 
   private:
-    image_data_directory header;
+    image_data_directory header{};
     const char*          data_;
     uint32_t             index_;
 };
@@ -196,11 +197,11 @@ class directories : public std::vector<directory*>
     {
         for (uint32_t i = 0;
              i < scn_->get_win_header()->get_number_of_rva_and_sizes(); ++i) {
-            directory* d = new directory(i);
+            std::unique_ptr<directory> d = std::make_unique< directory>(i);
             if (!d->load(stream)) {
                 return false;
             }
-            push_back(d);
+            push_back(d.release());
         }
         return true;
     }

--- a/coffi/coffi_relocation.hpp
+++ b/coffi/coffi_relocation.hpp
@@ -167,7 +167,7 @@ class relocation
     const symbol_provider*         sym_;
     const architecture_provider*   arch_;
     std::string                    symbol_name;
-    rel_entry_generic              header;
+    rel_entry_generic              header{};
 };
 
 } // namespace COFFI

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -354,7 +354,7 @@ template <class T> class section_impl_tmpl : public section
 
     //------------------------------------------------------------------------------
     T                        header;
-    uint32_t                 index;
+    uint32_t                 index{};
     std::string              name;
     char*                    data_;
     uint32_t                 data_reserved_;

--- a/coffi/coffi_symbols.hpp
+++ b/coffi/coffi_symbols.hpp
@@ -119,8 +119,8 @@ class symbol
     {
         set_aux_symbols_number(narrow_cast<uint8_t>(auxs.size()));
         stream.write(reinterpret_cast<char*>(&header), sizeof(header));
-        for (auto aux : auxs) {
-            stream.write(reinterpret_cast<char*>(&aux), sizeof(symbol_record));
+        for (auto const& aux : auxs) {
+            stream.write(reinterpret_cast<char const*>(&aux), sizeof(symbol_record));
         }
     }
 


### PR DESCRIPTION
- Fixing two potential leaks using std::unique_ptr respectively (The pointers are used for locals that are later inserted into a vector)
- Fixing some cases of uninitialized class members
- Changing one range-based for loop to use a const reference instead of copying locally
- Mentioning that C++14 is a minimum requirement (looking closely at some existing code, it has been for a while)