### PR TITLE
Fix multiple bugs, undefined behavior, and MSVC warnings

### DIFF
--- a/coffi/coffi.hpp
+++ b/coffi/coffi.hpp
@@ -730,10 +730,10 @@ class coffi : public coffi_strings,
 
             uint32_t size_of_headers = dos_header_->get_stub_size() +
                 CI_NIDENT1 +
-                coff_header_->get_sizeof() +
+                narrow_cast<uint32_t>(coff_header_->get_sizeof()) +
                 coff_header_->get_optional_header_size();
             for (const auto& section : sections_) {
-              size_of_headers += section.get_sizeof();
+              size_of_headers += narrow_cast<uint32_t>(section.get_sizeof());
             }
             size_of_headers = alignTo(size_of_headers, file_alignment);
 

--- a/coffi/coffi.hpp
+++ b/coffi/coffi.hpp
@@ -409,9 +409,13 @@ class coffi : public coffi_strings,
         if (architecture_ == COFFI_ARCHITECTURE_TI) {
             optional_header_ = std::make_unique<optional_header_impl_ti>();
         }
-        coff_header_->set_optional_header_size(narrow_cast<uint16_t>(
-            optional_header_->get_sizeof() + win_header_->get_sizeof() +
-            directories_.get_count() * sizeof(image_data_directory)));
+        uint16_t opt_hdr_size = narrow_cast<uint16_t>(
+            optional_header_->get_sizeof() +
+            (win_header_ ? win_header_->get_sizeof() +
+                               directories_.get_count() *
+                                   sizeof(image_data_directory)
+                         : 0));
+        coff_header_->set_optional_header_size(opt_hdr_size);
     }
 
     //---------------------------------------------------------------------

--- a/coffi/coffi.hpp
+++ b/coffi/coffi.hpp
@@ -43,6 +43,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <cstring>
 #include <memory>
+#include <new>
 #include <vector>
 
 #include <coffi/coffi_types.hpp>
@@ -987,7 +988,7 @@ class coffi : public coffi_strings,
                     file_alignment - (previous_size % file_alignment);
                 if (previous_dp && previous_dp->type == DATA_PAGE_RAW) {
                     // Extend the previous section data
-                    std::unique_ptr<char[]> padding = std::make_unique<char[]>(size);
+                    std::unique_ptr<char[]> padding(new(std::nothrow) char[size]());
                     if (padding) {
                         std::memset(padding.get(), 0, size);
                         sections_[previous_dp->index]->append_data(padding.get(),
@@ -1021,7 +1022,7 @@ class coffi : public coffi_strings,
     add_unused_space(uint32_t offset, uint32_t size, uint8_t padding_byte = 0)
     {
         unused_space us;
-        us.data = std::make_unique<char[]>(size);
+        us.data.reset(new(std::nothrow) char[size]());
         if (us.data) {
             std::memset(us.data.get(), padding_byte, size);
             us.size   = size;

--- a/coffi/coffi.hpp
+++ b/coffi/coffi.hpp
@@ -33,6 +33,12 @@ THE SOFTWARE.
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4996)
+// C4250: 'coffi' inherits 'coffi_strings::method' via dominance.
+// This is expected and correct — coffi uses diamond virtual inheritance
+// (coffi_strings and coffi_symbols both virtually inherit
+// string_to_name_provider). The dominant path through coffi_strings
+// is the intended resolution; the behavior is well-defined in C++.
+#pragma warning(disable : 4250)
 //#pragma warning(disable:4355)
 //#pragma warning(disable:4244)
 #endif

--- a/coffi/coffi.hpp
+++ b/coffi/coffi.hpp
@@ -340,7 +340,6 @@ class coffi : public coffi_strings,
         else {
             return save_to_stream(stream);
         }
-        return true;
     }
 
     //---------------------------------------------------------------------

--- a/coffi/coffi_directory.hpp
+++ b/coffi/coffi_directory.hpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 
 #include <iostream>
 #include <memory>
+#include <new>
 #include <vector>
 
 #include <coffi/coffi_utils.hpp>
@@ -87,7 +88,7 @@ class directory
             return;
         }
 
-        std::unique_ptr<char[]> temp_buffer = std::make_unique<char[]>(size);
+        std::unique_ptr<char[]> temp_buffer(new(std::nothrow) char[size]());
         if (!temp_buffer) {
             set_size(0);
             return;
@@ -126,7 +127,10 @@ class directory
             return true;
         }
         if ((get_size() > 0) && (get_virtual_address() != 0)) {
-            std::unique_ptr<char[]> temp_buffer = std::make_unique<char[]>(get_size());
+            std::unique_ptr<char[]> temp_buffer(new(std::nothrow) char[get_size()]());
+            if (!temp_buffer) {
+                return false;
+            }
             stream.seekg(get_virtual_address());
             stream.read(temp_buffer.get(), get_size());
             if (stream.gcount() != static_cast<std::streamsize>(get_size())) {

--- a/coffi/coffi_directory.hpp
+++ b/coffi/coffi_directory.hpp
@@ -129,7 +129,7 @@ class directory
             std::unique_ptr<char[]> temp_buffer = std::make_unique<char[]>(get_size());
             stream.seekg(get_virtual_address());
             stream.read(temp_buffer.get(), get_size());
-            if (stream.gcount() != static_cast<int>(get_size())) {
+            if (stream.gcount() != static_cast<std::streamsize>(get_size())) {
                 return false;
             }
             data_ = std::move(temp_buffer);

--- a/coffi/coffi_headers.hpp
+++ b/coffi/coffi_headers.hpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 
 #include <string>
 #include <iostream>
+#include <new>
 
 #include <coffi/coffi_utils.hpp>
 
@@ -126,7 +127,7 @@ class dos_header
 
         if (get_pe_sign_location() > static_cast<int32_t>(sizeof(header))) {
             stub_size_      = get_pe_sign_location() - sizeof(header);
-            std::unique_ptr<char[]> read_stub = std::make_unique<char[]>(stub_size_);
+            std::unique_ptr<char[]> read_stub(new(std::nothrow) char[stub_size_]());
             if (!read_stub) {
                 return false;
             }
@@ -175,7 +176,7 @@ class dos_header
             stub_.reset();
         }
         stub_size_     = size;
-        std::unique_ptr<char[]> new_stub = std::make_unique<char[]>(stub_size_);
+        std::unique_ptr<char[]> new_stub(new(std::nothrow) char[stub_size_]());
         if (!new_stub) {
             stub_size_ = 0;
         }

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -186,6 +186,7 @@ template <class T> class section_impl_tmpl : public section
     {
         if (!data_) {
             set_data(data, size);
+            return;
         }
         if (get_data_size() + size <= data_reserved_) {
             std::copy(data, data + size, data_.get() + get_data_size());

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -324,7 +324,7 @@ template <class T> class section_impl_tmpl : public section
     virtual void save_line_numbers(std::ostream& stream)
     {
         for (const auto& lnum : line_numbers) {
-            stream.write(reinterpret_cast<char*>(&lnum), sizeof(line_number));
+            stream.write(reinterpret_cast<const char*>(&lnum), sizeof(line_number));
         }
     }
 

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -131,18 +131,8 @@ template <class T> class section_impl_tmpl : public section
     COFFI_GET_SET_ACCESS(uint32_t, virtual_address);
     COFFI_GET_SET_ACCESS(uint32_t, data_offset);
     COFFI_GET_SET_ACCESS(uint32_t, reloc_offset);
-    uint32_t get_reloc_count() const { return header.reloc_count; }
-    void set_reloc_count(uint32_t value)
-    {
-        header.reloc_count =
-            narrow_cast<decltype(header.reloc_count)>(value);
-    }
-    uint32_t get_line_num_count() const { return header.line_num_count; }
-    void set_line_num_count(uint32_t value)
-    {
-        header.line_num_count =
-            narrow_cast<decltype(header.line_num_count)>(value);
-    }
+    COFFI_GET_SET_ACCESS(uint32_t, reloc_count);
+    COFFI_GET_SET_ACCESS(uint32_t, line_num_count);
     COFFI_GET_SET_ACCESS(uint32_t, flags);
 
     COFFI_GET_SIZEOF();

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -389,7 +389,11 @@ class section_impl : public section_impl_tmpl<section_header>
     //------------------------------------------------------------------------------
     uint32_t get_alignment() const
     {
-        return 1 << (((get_flags() >> 20) & 0xF) - 1);
+        uint32_t align_nibble = (get_flags() >> 20) & 0xF;
+        if (align_nibble == 0) {
+            return 1;
+        }
+        return 1u << (align_nibble - 1);
     }
 
     //------------------------------------------------------------------------------

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 
 #include <string>
 #include <iostream>
+#include <new>
 
 #include <coffi/coffi_utils.hpp>
 #include <coffi/coffi_relocation.hpp>
@@ -163,7 +164,7 @@ template <class T> class section_impl_tmpl : public section
             data_reserved_ = 0;
         }
         else {
-            data_ = std::make_unique<char[]>(size);
+            data_.reset(new(std::nothrow) char[size]());
             if (data_) {
                 data_reserved_ = size;
                 std::copy(data, data + size, data_.get());
@@ -193,7 +194,7 @@ template <class T> class section_impl_tmpl : public section
         }
         else {
             uint32_t new_data_size = 2 * (data_reserved_ + size);
-            std::unique_ptr<char[]> new_data = std::make_unique<char[]>(new_data_size);
+            std::unique_ptr<char[]> new_data(new(std::nothrow) char[new_data_size]());
             if (!new_data) {
                 size = 0;
             }
@@ -246,7 +247,7 @@ template <class T> class section_impl_tmpl : public section
         if (!dont) {
             data_reserved_ = get_data_size();
             if ((get_data_offset() != 0) && (data_reserved_ != 0)) {
-                data_ = std::make_unique<char[]>(data_reserved_);
+                data_.reset(new(std::nothrow) char[data_reserved_]());
                 if (!data_) {
                     return false;
                 }

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -296,7 +296,7 @@ template <class T> class section_impl_tmpl : public section
     //------------------------------------------------------------------------------
     virtual void save_relocations(std::ostream& stream)
     {
-        for (auto entry : relocations) {
+        for (auto& entry : relocations) {
             entry.save(stream);
         }
     }
@@ -311,7 +311,7 @@ template <class T> class section_impl_tmpl : public section
     //------------------------------------------------------------------------------
     virtual void save_line_numbers(std::ostream& stream)
     {
-        for (auto lnum : line_numbers) {
+        for (const auto& lnum : line_numbers) {
             stream.write(reinterpret_cast<char*>(&lnum), sizeof(line_number));
         }
     }

--- a/coffi/coffi_section.hpp
+++ b/coffi/coffi_section.hpp
@@ -131,8 +131,18 @@ template <class T> class section_impl_tmpl : public section
     COFFI_GET_SET_ACCESS(uint32_t, virtual_address);
     COFFI_GET_SET_ACCESS(uint32_t, data_offset);
     COFFI_GET_SET_ACCESS(uint32_t, reloc_offset);
-    COFFI_GET_SET_ACCESS(uint32_t, reloc_count);
-    COFFI_GET_SET_ACCESS(uint32_t, line_num_count);
+    uint32_t get_reloc_count() const { return header.reloc_count; }
+    void set_reloc_count(uint32_t value)
+    {
+        header.reloc_count =
+            narrow_cast<decltype(header.reloc_count)>(value);
+    }
+    uint32_t get_line_num_count() const { return header.line_num_count; }
+    void set_line_num_count(uint32_t value)
+    {
+        header.line_num_count =
+            narrow_cast<decltype(header.line_num_count)>(value);
+    }
     COFFI_GET_SET_ACCESS(uint32_t, flags);
 
     COFFI_GET_SIZEOF();
@@ -306,7 +316,8 @@ template <class T> class section_impl_tmpl : public section
     virtual uint32_t get_relocations_filesize()
     {
         relocation rel{stn_, sym_, arch_};
-        return rel.get_sizeof() * narrow_cast<uint32_t>(relocations.size());
+        return narrow_cast<uint32_t>(rel.get_sizeof()) *
+               narrow_cast<uint32_t>(relocations.size());
     }
 
     //------------------------------------------------------------------------------
@@ -320,7 +331,8 @@ template <class T> class section_impl_tmpl : public section
     //------------------------------------------------------------------------------
     virtual uint32_t get_line_numbers_filesize()
     {
-        return sizeof(line_number) * narrow_cast<uint32_t>(line_numbers.size());
+        return narrow_cast<uint32_t>(sizeof(line_number)) *
+               narrow_cast<uint32_t>(line_numbers.size());
     }
 
     //------------------------------------------------------------------------------

--- a/coffi/coffi_strings.hpp
+++ b/coffi/coffi_strings.hpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #define COFFI_STRINGS_HPP
 
 #include <cstring>
+#include <new>
 
 #include <coffi/coffi_utils.hpp>
 #include <coffi/coffi_headers.hpp>
@@ -106,7 +107,7 @@ class coffi_strings : public virtual string_to_name_provider
     //---------------------------------------------------------------------
     virtual void set_strings(const char* str, uint32_t size)
     {
-        std::unique_ptr<char[]> new_strings = std::make_unique<char[]>(size);
+        std::unique_ptr<char[]> new_strings(new(std::nothrow) char[size]());
         if (new_strings) {
             std::copy(str, str + size, new_strings.get());
             strings_          = std::move(new_strings);
@@ -142,7 +143,7 @@ class coffi_strings : public virtual string_to_name_provider
             header->get_symbols_count() * sizeof(symbol_record);
         stream.seekg(strings_offset);
         stream.read(strings_.get(), 4);
-        std::unique_ptr<char[]> new_strings = std::make_unique<char[]>(get_strings_size());
+        std::unique_ptr<char[]> new_strings(new(std::nothrow) char[get_strings_size()]());
         if (!new_strings) {
             return false;
         }
@@ -200,7 +201,7 @@ class coffi_strings : public virtual string_to_name_provider
             if (get_strings_size() + size > strings_reserved_) {
                 uint32_t new_strings_reserved =
                     2 * (strings_reserved_ + narrow_cast<uint32_t>(size));
-                std::unique_ptr<char[]> new_strings = std::make_unique<char[]>(new_strings_reserved);
+                std::unique_ptr<char[]> new_strings(new(std::nothrow) char[new_strings_reserved]());
                 if (!new_strings) {
                     offset = 0;
                     size   = 0;

--- a/coffi/coffi_symbols.hpp
+++ b/coffi/coffi_symbols.hpp
@@ -156,6 +156,9 @@ class coffi_symbols : public virtual symbol_provider,
     //! @copydoc symbol_provider::get_symbol(uint32_t)
     virtual const symbol* get_symbol(uint32_t index) const
     {
+        if (symbols_.empty()) {
+            return nullptr;
+        }
         uint32_t L = 0;
         uint32_t R = narrow_cast<uint32_t>(symbols_.size()) - 1;
         while (L <= R) {

--- a/coffi/coffi_symbols.hpp
+++ b/coffi/coffi_symbols.hpp
@@ -247,7 +247,7 @@ class coffi_symbols : public virtual symbol_provider,
     //---------------------------------------------------------------------
     void save_symbols(std::ostream& stream)
     {
-        for (auto s : symbols_) {
+        for (auto& s : symbols_) {
             s.save(stream);
         }
     }
@@ -256,7 +256,7 @@ class coffi_symbols : public virtual symbol_provider,
     uint32_t get_symbols_filesize()
     {
         uint32_t filesize = 0;
-        for (auto s : symbols_) {
+        for (const auto& s : symbols_) {
             filesize +=
                 sizeof(symbol_record) *
                 (1 + narrow_cast<uint32_t>(s.get_auxiliary_symbols().size()));

--- a/coffi/coffi_utils.hpp
+++ b/coffi/coffi_utils.hpp
@@ -65,12 +65,12 @@ THE SOFTWARE.
 
 //! Defines a **set_NAME** function for accessing the **NAME** structure field.
 #define COFFI_SET_ACCESS(TYPE, NAME) \
-    void set_##NAME(TYPE value) { header.NAME = value; }
+    void set_##NAME(TYPE value) { header.NAME = narrow_cast<decltype(header.NAME)>(value); }
 
 //! Defines a **get_NAME** and a **set_NAME** functions for accessing the **NAME** structure field.
 #define COFFI_GET_SET_ACCESS(TYPE, NAME)            \
     TYPE get_##NAME() const { return header.NAME; } \
-    void set_##NAME(TYPE value) { header.NAME = value; }
+    void set_##NAME(TYPE value) { header.NAME = narrow_cast<decltype(header.NAME)>(value); }
 
 //! Disables the **get_NAME** function for prohibiting read accesses to the **NAME** structure field.
 #define COFFI_GET_ACCESS_NONE(TYPE, NAME)                        \

--- a/coffi/coffi_utils.hpp
+++ b/coffi/coffi_utils.hpp
@@ -186,7 +186,7 @@ template <typename T> class unique_ptr_collection
 
         const_iterator operator++(int)
         {
-            iterator tmp = *this;
+            const_iterator tmp = *this;
             iterator_++;
             return tmp;
         }


### PR DESCRIPTION
## Summary

Fixes #19 — Multiple bugs, undefined behavior, and MSVC warnings found during thorough code review.

**This code was generated with the assistance of [Claude Code](https://claude.com/claude-code) (Anthropic Claude Opus 4.6).** Every change has been manually reviewed and verified one-by-one by [@scc-tw](https://github.com/scc-tw). I take full responsibility for these changes working as expected.

## Changes

### Critical fixes (crash / UB)
- **`coffi_symbols.hpp`**: Fix integer underflow in `get_symbol()` when symbol table is empty — `symbols_.size() - 1` wraps to `0xFFFFFFFF`, causing OOB access
- **`coffi_section.hpp`**: Add missing `return` in `append_data()` — without it, data is written twice and `data_size` is doubled
- **`coffi_section.hpp`**: Fix undefined behavior in `section_impl::get_alignment()` — `1 << (0 - 1)` is UB when alignment nibble is 0
- **`coffi.hpp`**: Guard `win_header_->get_sizeof()` null dereference in `create_optional_header()` for CEVA/TI architectures

### Correctness fixes
- **Multiple files**: Replace `std::make_unique<char[]>` with `new(std::nothrow)` so existing null checks actually work (`make_unique` throws, never returns null)
- **`coffi.hpp`**: Remove unreachable `return true` in `save()`
- **`coffi_utils.hpp`**: Fix `const_iterator::operator++(int)` using wrong type (`iterator` instead of `const_iterator`)
- **`coffi_directory.hpp`**: Use `std::streamsize` instead of `int` cast in `load_data()` to avoid truncation for sizes > 2GB

### Performance
- **`coffi_symbols.hpp`, `coffi_section.hpp`**: Use references in for-loops to avoid copying symbol/relocation/line_number objects

### MSVC warning cleanup (C4244, C4267, C4250)
- **`coffi_utils.hpp`**: Fix `COFFI_SET_ACCESS` and `COFFI_GET_SET_ACCESS` macros to use `narrow_cast<decltype(header.NAME)>(value)` — this globally fixes all narrowing conversion warnings (C4244, C4267) without touching individual call sites
- **`coffi.hpp`**: Apply `narrow_cast` to `get_sizeof()` calls in `size_of_headers` computation
- **`coffi_section.hpp`**: Apply `narrow_cast` to `get_relocations_filesize()` and `get_line_numbers_filesize()` return expressions
- **`coffi.hpp`**: Suppress C4250 (diamond virtual inheritance dominance) with explanatory comment — the behavior is well-defined in C++

## Build verification

Clean compilation on MSVC 14.50 (VS 18), Windows 11 x64. Before and after:

**Before (warnings on every TU that includes coffi.hpp):**
```
coffi_headers.hpp(503,5): warning C4244: '=': converting 'uint64_t' to 'uint32_t', possible loss of data
coffi_headers.hpp(502,5): warning C4244: '=': converting 'uint64_t' to 'uint32_t', possible loss of data
coffi_headers.hpp(501,5): warning C4244: '=': converting 'uint64_t' to 'uint32_t', possible loss of data
coffi_headers.hpp(500,5): warning C4244: '=': converting 'uint64_t' to 'uint32_t', possible loss of data
coffi_headers.hpp(485,5): warning C4244: '=': converting 'uint64_t' to 'uint32_t', possible loss of data
coffi.hpp(731,38): warning C4267: 'initializing': converting 'size_t' to 'uint32_t', possible loss of data
coffi.hpp(736,52): warning C4267: '+=': converting 'size_t' to 'uint32_t', possible loss of data
coffi.hpp(71,7): warning C4250: 'COFFI::coffi': inherits 'COFFI::coffi_strings::...' via dominance (×4)
```

**After:** Zero C4244/C4267/C4250 warnings. Only C4819 (locale codepage) remains, which is environment-specific.

## Test plan

- [x] Verified `writer`, `write_obj`, `tutorial` examples compile cleanly on MSVC
- [x] Verified no regressions in existing compilation targets
- [x] Each fix reviewed individually for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Anthropic Claude Opus 4.6), manually verified by [@scc-tw](https://github.com/scc-tw)